### PR TITLE
Heartbeat

### DIFF
--- a/packages/watcher/src/configuration/environment/EnvConfiguration.test.ts
+++ b/packages/watcher/src/configuration/environment/EnvConfiguration.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '../../logger/Logger';
 import { EnvConfiguration } from './EnvConfiguration';
 import { InvalidEnvironmentException } from './InvalidEnvironmentException';
 
@@ -6,7 +7,7 @@ describe('EnvConfiguration', () => {
     log: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-  };
+  } as unknown as Logger;
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/watcher/src/configuration/environment/schema.ts
+++ b/packages/watcher/src/configuration/environment/schema.ts
@@ -67,6 +67,12 @@ export interface EnvSchema {
    * @default http://host.docker.internal
    */
   EXTERNAL_KUBERNETES_PROXY_HOST: string | undefined;
+
+  /**
+   * The interval at which the service will send a heartbeat to the Podwatch Web Service, in milliseconds.
+   * @default 30000
+   */
+  HEARTBEAT_INTERVAL: string | undefined;
 }
 
 /**
@@ -129,6 +135,9 @@ const envSchema = Joi.object({
     .required(),
   PODWATCH_WEB_SERVICE_URL: Joi.string().required(),
   EXTERNAL_KUBERNETES_PROXY_HOST: Joi.string().required(),
+  HEARTBEAT_INTERVAL: Joi.string()
+    .required()
+    .regex(/^-?\d+$/),
 })
   .and('KUBERNETES_SERVICE_HOST', 'KUBERNETES_SERVICE_PORT')
   .and('PODWATCH_CLIENT_ID', 'PODWATCH_CLIENT_SECRET')

--- a/packages/watcher/src/dispatcher/EventDispatcher.ts
+++ b/packages/watcher/src/dispatcher/EventDispatcher.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { EnvConfiguration } from '../configuration/environment/EnvConfiguration';
 import { Logger } from '../logger/Logger';
 import { NativeKEvent } from '../types/NativeKEvent';
@@ -70,11 +70,8 @@ export class EventDispatcher {
       this.dataQueue = [];
       await this.webhookInstance.post('/watch', data);
     } catch (error: any) {
-      this.logger.error(
-        'Encountered an error dispatching error data: ',
-        error.message,
-        error
-      );
+      this.logger.error('Encountered an error dispatching error data: ');
+      this.logger.error(`Error: ${(error as AxiosError).message}`);
     }
   }
 

--- a/packages/watcher/src/heartbeat/Heartbeat.ts
+++ b/packages/watcher/src/heartbeat/Heartbeat.ts
@@ -46,7 +46,7 @@ export class Heartbeat {
    */
   private async sendData(heartbeatData: HearbeatData) {
     try {
-      await this.webhookInstance.post('/heartbeat', heartbeatData);
+      await this.webhookInstance.post('/status', heartbeatData);
     } catch (error) {
       this.logger.error('Failed to send heartbeat data', error);
     }

--- a/packages/watcher/src/heartbeat/Heartbeat.ts
+++ b/packages/watcher/src/heartbeat/Heartbeat.ts
@@ -26,6 +26,10 @@ export class Heartbeat {
    * The heartbeat method is responsible for queuing heartbeat data for dispatch. The queue is maintained to ensure all data is eventually sent to the Podwatch Service or custom server.
    */
   private heartbeat() {
+    this.logger.log(
+      'Sending heartbeat data with service status report and logs'
+    );
+
     this.dataQueue.push({
       status: this.logger.status,
       timestamp: new Date(),

--- a/packages/watcher/src/heartbeat/Heartbeat.ts
+++ b/packages/watcher/src/heartbeat/Heartbeat.ts
@@ -1,0 +1,45 @@
+import { AxiosInstance } from 'axios';
+import { EnvConfiguration } from '../configuration/environment/EnvConfiguration';
+import { ServiceStatus } from '../types/ServiceStatus';
+import { Logger } from './../logger/Logger';
+
+interface HearbeatData {
+  status: ServiceStatus;
+  timestamp: Date;
+  logs: Log[];
+}
+
+export class Heartbeat {
+  private timeInterval: number;
+  private dataQueue: HearbeatData[] = [];
+
+  constructor(
+    private readonly webhookInstance: AxiosInstance,
+    private readonly config: EnvConfiguration,
+    private readonly logger: Logger
+  ) {
+    this.timeInterval = Number(this.config.get('HEARTBEAT_INTERVAL'));
+
+    setInterval(() => {
+      this.heartbeat();
+    }, this.timeInterval);
+  }
+
+  private heartbeat() {
+    this.dataQueue.push({
+      status: this.logger.status,
+      timestamp: new Date(),
+      logs: this.logger.flush(),
+    });
+  }
+
+  private async sendData() {
+    const heartbeatData = this.dataQueue.shift();
+
+    try {
+      await this.webhookInstance.post('/heartbeat', heartbeatData);
+    } catch (error) {
+      this.logger.error('Failed to send heartbeat data', error);
+    }
+  }
+}

--- a/packages/watcher/src/heartbeat/Heartbeat.ts
+++ b/packages/watcher/src/heartbeat/Heartbeat.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { EnvConfiguration } from '../configuration/environment/EnvConfiguration';
 import { HearbeatData } from '../types/HeartbeatData';
 import { Logger } from './../logger/Logger';
@@ -51,8 +51,9 @@ export class Heartbeat {
   private async sendData(heartbeatData: HearbeatData) {
     try {
       await this.webhookInstance.post('/status', heartbeatData);
-    } catch (error) {
-      this.logger.error('Failed to send heartbeat data', error);
+    } catch (error: unknown) {
+      this.logger.error('Failed to send heartbeat data');
+      this.logger.error(`Error: ${(error as AxiosError).message}`);
     }
   }
 }

--- a/packages/watcher/src/index.ts
+++ b/packages/watcher/src/index.ts
@@ -12,7 +12,7 @@ dotenv.config();
 
 const logger = new Logger();
 
-logger.log('Building environment configuration');
+logger.info('Building environment configuration');
 const config = new EnvConfiguration(
   {
     KUBERNETES_SERVICE_HOST: process.env.KUBERNETES_SERVICE_HOST,
@@ -36,27 +36,27 @@ const config = new EnvConfiguration(
   logger
 );
 
-logger.log('Validating environment configuration');
+logger.info('Validating environment configuration');
 config.validate();
 
-logger.log('Creating connection instance for cluster');
+logger.info('Creating connection instance for cluster');
 const kubernetesInstanceFactory = new KubernetesInstanceFactory(config, logger);
 const kubernetesInstance = kubernetesInstanceFactory.create();
 
-logger.log('Creating connection instance for webhook');
+logger.info('Creating connection instance for webhook');
 const webhookInstanceFactory = new WebhookInstanceFactory(config, logger);
 const webhookInstance = webhookInstanceFactory.create();
 
-logger.log('Creating heartbeat for service status reporting');
+logger.info('Creating heartbeat for service status reporting');
 new Heartbeat(webhookInstance, config, logger);
 
-logger.log('Instantiating JSON stream parser');
+logger.info('Instantiating JSON stream parser');
 const jsonStreamParser = new JsonStreamParser();
 
-logger.log('Instantiating event dispatcher');
+logger.info('Instantiating event dispatcher');
 const eventDispatcher = new EventDispatcher(webhookInstance, config, logger);
 
-logger.log('Instantiating event receiver');
+logger.info('Instantiating event receiver');
 const receiver = new EventReceiver(
   kubernetesInstance,
   jsonStreamParser,
@@ -64,5 +64,5 @@ const receiver = new EventReceiver(
   logger
 );
 
-logger.log('Starting event receiver');
+logger.info('Starting event receiver');
 receiver.start();

--- a/packages/watcher/src/index.ts
+++ b/packages/watcher/src/index.ts
@@ -6,6 +6,7 @@ import { Logger } from './logger/Logger';
 import { KubernetesInstanceFactory } from './axios-instances/KubernetesInstanceFactory';
 import { WebhookInstanceFactory } from './axios-instances/WebhookInstanceFactory';
 import dotenv from 'dotenv';
+import { Heartbeat } from './heartbeat/Heartbeat';
 
 dotenv.config();
 
@@ -45,6 +46,9 @@ const kubernetesInstance = kubernetesInstanceFactory.create();
 logger.log('Creating connection instance for webhook');
 const webhookInstanceFactory = new WebhookInstanceFactory(config, logger);
 const webhookInstance = webhookInstanceFactory.create();
+
+logger.log('Creating heartbeat for service status reporting');
+new Heartbeat(webhookInstance, config, logger);
 
 logger.log('Instantiating JSON stream parser');
 const jsonStreamParser = new JsonStreamParser();

--- a/packages/watcher/src/index.ts
+++ b/packages/watcher/src/index.ts
@@ -30,6 +30,7 @@ const config = new EnvConfiguration(
     EXTERNAL_KUBERNETES_PROXY_HOST:
       process.env.EXTERNAL_KUBERNETES_PROXY_HOST ||
       'http://host.docker.internal',
+    HEARTBEAT_INTERVAL: process.env.HEARTBEAT_INTERVAL || '30000',
   },
   logger
 );

--- a/packages/watcher/src/logger/Logger.ts
+++ b/packages/watcher/src/logger/Logger.ts
@@ -1,16 +1,78 @@
+import { ServiceStatus } from '../types/ServiceStatus';
+
 /**
  * The logger class provides a simple, centralized interface for logging messages to the console with different log levels.
  */
 export class Logger {
+  private logQueue: Log[] = [];
+  private serviceStatus: ServiceStatus = 'OK';
+
+  /**
+   * Logs a general log message to the console and saves it to the log queue
+   * @param message
+   * @param args
+   */
   public log(message: string, ...args: any[]): void {
+    const log = {
+      message,
+      args,
+      level: 'log',
+      timestamp: new Date(),
+    };
+
+    this.logQueue.push(log);
     console.info(message, ...args);
   }
 
+  /**
+   * Logs a warning message to the console and saves it to the log queue
+   * @param message
+   * @param args
+   */
   public warn(message: string, ...args: any[]): void {
+    const log = {
+      message,
+      args,
+      level: 'warn',
+      timestamp: new Date(),
+    };
+
+    this.logQueue.push(log);
     console.warn(message, ...args);
   }
 
+  /**
+   * Logs an error message to the console and saves it to the log queue. Sets the service status to ERROR.
+   * @param message
+   * @param args
+   */
   public error(message: string, ...args: any[]): void {
+    this.serviceStatus = 'ERROR';
+    const log = {
+      message,
+      args,
+      level: 'error',
+      timestamp: new Date(),
+    };
+
+    this.logQueue.push(log);
     console.error(message, ...args);
+  }
+
+  /**
+   * Returns the current service status. Defaults to OK if no errors have been logged.
+   */
+  public get status(): ServiceStatus {
+    return this.serviceStatus;
+  }
+
+  /**
+   * Gets the current log queue and resets it.
+   * @returns An array of Log objects
+   */
+  public flush(): Log[] {
+    const logs = this.logQueue;
+    this.logQueue = [];
+    return logs;
   }
 }

--- a/packages/watcher/src/logger/Logger.ts
+++ b/packages/watcher/src/logger/Logger.ts
@@ -1,4 +1,5 @@
 import { ServiceStatus } from '../types/ServiceStatus';
+import { Log } from '../types/Log';
 
 /**
  * The logger class provides a simple, centralized interface for logging messages to the console with different log levels.
@@ -8,15 +9,27 @@ export class Logger {
   private serviceStatus: ServiceStatus = 'OK';
 
   /**
-   * Logs a general log message to the console and saves it to the log queue
+   * Logs a general log message to the console. Does not save it to the log queue.
    * @param message
    * @param args
    */
   public log(message: string, ...args: any[]): void {
+    this.serviceStatus = 'OK';
+    console.log(message, ...args);
+  }
+
+  /**
+   * Logs an info message to the console and saves it to the log queue
+   * @param message
+   * @param args
+   */
+  public info(message: string, ...args: any[]): void {
+    this.serviceStatus = 'OK';
+
     const log = {
       message,
       args,
-      level: 'log',
+      level: 'info',
       timestamp: new Date(),
     };
 

--- a/packages/watcher/src/receiver/EventReceiver.ts
+++ b/packages/watcher/src/receiver/EventReceiver.ts
@@ -91,7 +91,7 @@ export class EventReceiver {
     this.logger.log('Received event with reason: ', event.object.reason);
 
     if (event.object.reason === 'Expired') {
-      this.logger.log(
+      this.logger.warn(
         'Latest resource version too old. Unsetting current resource version and restarting stream.'
       );
 
@@ -106,8 +106,8 @@ export class EventReceiver {
   }
 
   private handleStreamError(error: any) {
-    this.logger.error('Error in event stream: ');
-    this.logger.error(error);
+    this.logger.warn('Error in event stream: ');
+    this.logger.warn(error);
 
     this.handleStreamReconnect(1000);
   }
@@ -120,7 +120,7 @@ export class EventReceiver {
     this.ejectStream();
     if (this.shouldRestart()) {
       setTimeout(() => {
-        this.logger.log('Attempting to reconnect to event stream');
+        this.logger.info('Attempting to reconnect to event stream');
         this.establishEventStream();
       }, delay);
     }

--- a/packages/watcher/src/receiver/EventReceiver.ts
+++ b/packages/watcher/src/receiver/EventReceiver.ts
@@ -1,5 +1,5 @@
 import { NativeKEvent } from '../types/NativeKEvent';
-import { AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { JsonStreamParser } from '../json-parser/JsonStreamParser';
 import { EventDispatcher } from '../dispatcher/EventDispatcher';
 import { Logger } from '../logger/Logger';
@@ -107,7 +107,7 @@ export class EventReceiver {
 
   private handleStreamError(error: any) {
     this.logger.warn('Error in event stream: ');
-    this.logger.warn(error);
+    this.logger.warn(`Error: ${(error as AxiosError).message}`);
 
     this.handleStreamReconnect(1000);
   }

--- a/packages/watcher/src/types/HeartbeatData.ts
+++ b/packages/watcher/src/types/HeartbeatData.ts
@@ -1,0 +1,7 @@
+import { ServiceStatus } from './ServiceStatus';
+
+export interface HearbeatData {
+  status: ServiceStatus;
+  timestamp: Date;
+  logs: Log[];
+}

--- a/packages/watcher/src/types/HeartbeatData.ts
+++ b/packages/watcher/src/types/HeartbeatData.ts
@@ -1,3 +1,4 @@
+import { Log } from './Log';
 import { ServiceStatus } from './ServiceStatus';
 
 export interface HearbeatData {

--- a/packages/watcher/src/types/Log.ts
+++ b/packages/watcher/src/types/Log.ts
@@ -1,4 +1,4 @@
-interface Log {
+export interface Log {
   message: string;
   args: any[];
   level: string;

--- a/packages/watcher/src/types/Log.ts
+++ b/packages/watcher/src/types/Log.ts
@@ -1,0 +1,6 @@
+interface Log {
+  message: string;
+  args: any[];
+  level: string;
+  timestamp: Date;
+}

--- a/packages/watcher/src/types/ServiceStatus.ts
+++ b/packages/watcher/src/types/ServiceStatus.ts
@@ -1,0 +1,1 @@
+export type ServiceStatus = 'OK' | 'ERROR';

--- a/packages/webapp-server/src/controllers/kErrorController.ts
+++ b/packages/webapp-server/src/controllers/kErrorController.ts
@@ -96,8 +96,8 @@ export const kErrorController = {
       return next();
     } catch (error) {
       return next({
-        log: 'Error getting cluster from body',
-        message: 'Error getting cluster from body',
+        log: 'Error getting cluster',
+        message: 'Error getting cluster',
         status: 500,
         error,
       });

--- a/packages/webapp-server/src/controllers/statusController.ts
+++ b/packages/webapp-server/src/controllers/statusController.ts
@@ -15,11 +15,12 @@ export const statusController = {
       const statusUpdate = StatusModel.build({
         status,
         logs,
-        timestamp,
+        timestamp: new Date(timestamp),
         cluster: clusterId,
       });
 
       await statusUpdate.save();
+      return next();
     } catch (error) {
       return next({
         log: 'Error saving status',

--- a/packages/webapp-server/src/controllers/statusController.ts
+++ b/packages/webapp-server/src/controllers/statusController.ts
@@ -9,6 +9,8 @@ export const statusController = {
     const clusterId = res.locals.cluster.id;
     const { status, logs, timestamp } = req.body;
 
+    console.log(`Received heartbeat from ${clusterId}: ${status}`);
+
     try {
       const statusUpdate = StatusModel.build({
         status,

--- a/packages/webapp-server/src/controllers/statusController.ts
+++ b/packages/webapp-server/src/controllers/statusController.ts
@@ -1,0 +1,64 @@
+import { NextFunction, Request, Response } from 'express';
+import { StatusModel } from '../models/StatusModel';
+
+export const statusController = {
+  processHeartbeat: async (req: Request, res: Response, next: NextFunction) => {
+    const clusterId = res.locals.cluster.id;
+    const { status, logs, timestamp } = req.body;
+
+    try {
+      const statusUpdate = StatusModel.build({
+        status,
+        logs,
+        timestamp,
+        cluster: clusterId,
+      });
+
+      await statusUpdate.save();
+    } catch (error) {
+      return next({
+        log: 'Error saving status',
+        message: 'Error saving status',
+        status: 500,
+        error,
+      });
+    }
+  },
+  getStatus: async (req: Request, res: Response, next: NextFunction) => {
+    const clusterId = res.locals.cluster.id;
+
+    try {
+      const status = (
+        await StatusModel.find({ cluster: clusterId }, null, {
+          sort: { timestamp: -1 },
+          limit: 1,
+        })
+      )[0];
+
+      if (!status) {
+        return next({
+          log: 'No status found',
+          message: 'No status found',
+          status: 404,
+        });
+      }
+
+      const heartbeatInterval = Number(process.env.HEARTBEAT_INTERVAL) || 30000;
+
+      // If it has been more than the interval plus 2 seconds since the last heartbeat, set status to OFFLINE in response
+      if (status.timestamp < new Date(Date.now() - heartbeatInterval - 2000)) {
+        status.status = 'OFFLINE';
+      }
+
+      res.locals.status = status;
+      return next();
+    } catch (error) {
+      return next({
+        log: 'Error getting status',
+        message: 'Error getting status',
+        status: 500,
+        error,
+      });
+    }
+  },
+};

--- a/packages/webapp-server/src/index.ts
+++ b/packages/webapp-server/src/index.ts
@@ -13,9 +13,9 @@ import authRouter from './routers/authRouter';
 import { errorHandler } from './errors/errorHandler';
 //import clusterRouter
 import clusterRouter from './routers/clusterRouter';
+import statusRouter from './routers/statusRouter';
 
 dotenv.config();
-
 
 const app = express();
 
@@ -35,6 +35,7 @@ app.use('/watch', watcherRouter);
 app.use('/kerrors', kErrorRouter);
 app.use('/auth', authRouter);
 app.use('/cluster', clusterRouter);
+app.use('/status', statusRouter);
 
 app.use(errorHandler);
 

--- a/packages/webapp-server/src/models/KErrorModel.ts
+++ b/packages/webapp-server/src/models/KErrorModel.ts
@@ -81,7 +81,8 @@ const kErrorSchema = new mongoose.Schema<KErrorAttrs>(
     },
     count: {
       type: Number,
-      required: true,
+      required: false,
+      default: 1,
     },
     firstTimestamp: {
       type: Date,

--- a/packages/webapp-server/src/models/StatusModel.ts
+++ b/packages/webapp-server/src/models/StatusModel.ts
@@ -1,0 +1,89 @@
+import { ClusterDocument } from './ClusterModel';
+import mongoose from 'mongoose';
+
+export type ServiceStatus = 'OK' | 'ERROR' | 'OFFLINE';
+
+export interface Log {
+  message: string;
+  args: any[];
+  level: string;
+  timestamp: Date;
+}
+
+export interface Status {
+  status: ServiceStatus;
+
+  timestamp: Date;
+
+  logs: Log[];
+
+  cluster: ClusterDocument;
+}
+
+export interface StatusAttrs extends Status {}
+
+export interface StatusDocument extends Status, mongoose.Document {
+  id: string;
+}
+
+export interface StatusModel extends mongoose.Model<StatusDocument> {
+  build(attrs: StatusAttrs): StatusDocument;
+}
+
+const statusSchema = new mongoose.Schema(
+  {
+    status: {
+      type: String,
+      required: true,
+      enum: ['OK', 'ERROR'],
+    },
+    timestamp: {
+      type: Date,
+      required: true,
+    },
+    logs: [
+      {
+        message: {
+          type: String,
+          required: true,
+        },
+        args: {
+          type: Array,
+          required: true,
+        },
+        level: {
+          type: String,
+          required: true,
+        },
+        timestamp: {
+          type: Date,
+          required: true,
+        },
+      },
+    ],
+    cluster: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Cluster',
+      required: true,
+    },
+  },
+  {
+    toJSON: {
+      virtuals: true,
+    },
+    toObject: {
+      virtuals: true,
+    },
+  }
+);
+
+statusSchema.statics.build = (attrs: StatusAttrs) => {
+  return new StatusModel(attrs);
+};
+
+const StatusModel = mongoose.model<StatusDocument, StatusModel>(
+  'Status',
+  statusSchema
+);
+
+export { StatusModel };

--- a/packages/webapp-server/src/routers/statusRouter.ts
+++ b/packages/webapp-server/src/routers/statusRouter.ts
@@ -10,7 +10,7 @@ statusRouter.post(
   kErrorController.getClusterFromHeaders,
   statusController.processHeartbeat,
   (req: Request, res: Response) => {
-    res.sendStatus(200);
+    res.status(200).send('OK');
   }
 );
 
@@ -30,7 +30,7 @@ statusRouter.get(
   kErrorController.getClusterFromParams,
   statusController.getStatusLogs,
   (req: Request, res: Response) => {
-    res.status(200).json(res.locals.status);
+    res.status(200).json(res.locals.logs);
   }
 );
 

--- a/packages/webapp-server/src/routers/statusRouter.ts
+++ b/packages/webapp-server/src/routers/statusRouter.ts
@@ -1,0 +1,27 @@
+import { Request, Response, Router } from 'express';
+import { authenticateUser } from '../controllers/authController';
+import { kErrorController } from '../controllers/kErrorController';
+import { statusController } from '../controllers/statusController';
+
+const statusRouter = Router();
+
+statusRouter.post(
+  '/',
+  kErrorController.getClusterFromHeaders,
+  statusController.processHeartbeat,
+  (req: Request, res: Response) => {
+    res.sendStatus(200);
+  }
+);
+
+statusRouter.get(
+  '/:clusterId',
+  authenticateUser,
+  kErrorController.getClusterFromParams,
+  statusController.getStatus,
+  (req: Request, res: Response) => {
+    res.status(200).json(res.locals.status);
+  }
+);
+
+export default statusRouter;

--- a/packages/webapp-server/src/routers/statusRouter.ts
+++ b/packages/webapp-server/src/routers/statusRouter.ts
@@ -24,4 +24,14 @@ statusRouter.get(
   }
 );
 
+statusRouter.get(
+  '/:clusterId/logs',
+  authenticateUser,
+  kErrorController.getClusterFromParams,
+  statusController.getStatusLogs,
+  (req: Request, res: Response) => {
+    res.status(200).json(res.locals.status);
+  }
+);
+
 export default statusRouter;

--- a/packages/webapp-server/src/routers/watcherRouter.ts
+++ b/packages/webapp-server/src/routers/watcherRouter.ts
@@ -8,7 +8,6 @@ watcherRouter.post(
   kErrorController.getClusterFromHeaders,
   kErrorController.saveAll,
   (req: Request, res: Response) => {
-    console.log(req.body);
     res.status(200).send('OK');
   }
 );


### PR DESCRIPTION
Set up Watcher service to report its status periodically using a "heartbeat" API call.
Beefed up logging in Watcher service to be more usable in the hearbeat status calls.
Added controller and router to receive heartbeat calls and provide query access to the frontend.